### PR TITLE
Fixes #32 Settings Don’t Save

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -33,6 +33,18 @@ class Plugin extends \craft\base\Plugin
      */
     public $hasCpSettings = true;
 
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+        $this->settings->setSections();
+    }
+
     // Protected Methods
     // =========================================================================
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -31,6 +31,11 @@ class Settings extends Model
     public $entryVariable = 'entry';
 
     /**
+     * @var array The settings for each section
+     */
+    public $sections = [];
+
+    /**
      * @var SectionSettings[]
      */
     private $_sections = [];
@@ -61,12 +66,10 @@ class Settings extends Model
 
     /**
      * Sets the section settings.
-     *
-     * @param array $sections
      */
-    public function setSections(array $sections)
+    public function setSections()
     {
-        foreach ($sections as $key => $config) {
+        foreach ($this->sections as $key => $config) {
             // Ignore sections that don't allow guest submissions
             if ($config['allowGuestSubmissions']) {
                 $this->_sections[$config['sectionId']] = new SectionSettings($config);


### PR DESCRIPTION
Added init() in plugin.php to call $settings->setSections(). Added $sections array to store section settings. Removed $sections param from setSections().