### PR TITLE
allowAnonymous support (craft 3.2)

### DIFF
--- a/src/controllers/SaveController.php
+++ b/src/controllers/SaveController.php
@@ -34,7 +34,9 @@ class SaveController extends Controller
     /**
      * @inheritdoc
      */
-    protected $allowAnonymous = true;
+    protected $allowAnonymous = [
+        'index' => self::ALLOW_ANONYMOUS_LIVE
+    ];
 
     // Constants
     // =========================================================================


### PR DESCRIPTION
Fix for the way craft 3.2 handles $allowAnonymous in controllers.