### PR TITLE
Use `asModelFailure` and `asModelSuccess` in v4

### DIFF
--- a/src/controllers/SaveController.php
+++ b/src/controllers/SaveController.php
@@ -161,22 +161,11 @@ class SaveController extends Controller
             ]));
         }
 
-        if (Craft::$app->getRequest()->getAcceptsJson()) {
-            return $this->asJson([
-                'success' => true,
-                'id' => $entry->id,
-                'title' => $entry->title,
-                'authorUsername' => $entry->getAuthor()->username,
-                'dateCreated' => DateTimeHelper::toIso8601($entry->dateCreated),
-                'dateUpdated' => DateTimeHelper::toIso8601($entry->dateUpdated),
-                'postDate' => $entry->postDate ? DateTimeHelper::toIso8601($entry->postDate) : null,
-                'url' => $entry->getUrl(),
-            ]);
-        }
-
-        $this->setSuccessFlash(Craft::t('guest-entries', 'Entry saved.'));
-
-        return $this->redirectToPostedUrl($entry);
+        return $this->asModelSuccess(
+            $entry,
+            Craft::t('guest-entries', 'Entry saved.'),
+            $settings->entryVariable,
+        );
     }
 
     /**
@@ -184,9 +173,9 @@ class SaveController extends Controller
      *
      * @param Settings $settings
      * @param Entry $entry
-     * @return Response|null
+     * @return Response
      */
-    private function _returnError(Settings $settings, Entry $entry)
+    private function _returnError(Settings $settings, Entry $entry): Response
     {
         if ($this->hasEventHandlers(self::EVENT_AFTER_ERROR)) {
             $this->trigger(self::EVENT_AFTER_ERROR, new SaveEvent([
@@ -194,23 +183,11 @@ class SaveController extends Controller
             ]));
         }
 
-        if (Craft::$app->getRequest()->getAcceptsJson()) {
-            return $this->asJson([
-                'success' => false,
-                'errors' => $entry->getErrors(),
-            ]);
-        }
-
-        $this->setFailFlash(Craft::t('guest-entries', 'Couldn’t save entry.'));
-
-        // Send the entry back to the template
-        /** @var UrlManager $urlManager */
-        $urlManager = Craft::$app->getUrlManager();
-        $urlManager->setRouteParams([
-            'variables' => [$settings->entryVariable => $entry],
-        ]);
-
-        return null;
+        return $this->asModelFailure(
+            $entry,
+            Craft::t('guest-entries', 'Couldn’t save entry.'),
+            $settings->entryVariable,
+        );
     }
 
     /**

--- a/src/controllers/SaveController.php
+++ b/src/controllers/SaveController.php
@@ -19,7 +19,6 @@ use craft\helpers\Db;
 use craft\models\Section;
 use craft\web\Controller;
 use craft\web\Request;
-use craft\web\UrlManager;
 use yii\web\BadRequestHttpException;
 use yii\web\NotFoundHttpException;
 use yii\web\Response;

--- a/src/controllers/SaveController.php
+++ b/src/controllers/SaveController.php
@@ -164,7 +164,7 @@ class SaveController extends Controller
         return $this->asModelSuccess(
             $entry,
             Craft::t('guest-entries', 'Entry saved.'),
-            $settings->entryVariable,
+            'entry',
         );
     }
 


### PR DESCRIPTION
This PR changes the return values of failure and success responses to use Craft’s `asModelFailure` and `asModelSuccess` controller methods. This helps standardise response structures and brings them in-line with how things have been done since Craft 4. 

This introduces a breaking change for the return values of JSON responses (https://github.com/craftcms/guest-entries/blob/main/README.md#submitting-via-ajax), therefore it should be considered it for version 4 (with Craft 5 compatibility).

I’m specifically requesting this change to make it easier for Sprig v3 to handle responses from the `SaveController`, which otherwise have to be handled individually, due to this inconsistency:
https://github.com/putyourlightson/craft-sprig-core/blob/f7b60d416d935a4dd089a4b43d682087a79b991a/src/controllers/ComponentsController.php#L106-L108