### PR TITLE
Fix #87 - Correct return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Guest Entries
 
+## Unreleased
+
+### Fixed
+- Fixed a PHP error that could occur on validation failure. ([#87](https://github.com/craftcms/guest-entries/issues/87))
+
 ## 4.0.0 - 2024-03-19
 
 - Added Craft 5 compatibility.

--- a/src/controllers/SaveController.php
+++ b/src/controllers/SaveController.php
@@ -176,9 +176,9 @@ class SaveController extends Controller
      *
      * @param Settings $settings
      * @param Entry $entry
-     * @return Response
+     * @return Response|null
      */
-    private function _returnError(Settings $settings, Entry $entry): Response
+    private function _returnError(Settings $settings, Entry $entry): ?Response
     {
         if ($this->hasEventHandlers(self::EVENT_AFTER_ERROR)) {
             $this->trigger(self::EVENT_AFTER_ERROR, new SaveEvent([


### PR DESCRIPTION
Correct return type to match `asModelFailure()` (issue #87)

